### PR TITLE
PPS-39: Fix warnings in tests

### DIFF
--- a/src/components/AuthControl/test/AuthControl.test.js
+++ b/src/components/AuthControl/test/AuthControl.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { addIcons } from '../../../config/fontawesome';
 import AuthControl from '..';
+
+beforeAll(() => {
+    addIcons();
+});
 
 describe('AuthControl', () => {
     it('should render without crashing', () => {

--- a/src/components/Drawer/test/Drawer.test.js
+++ b/src/components/Drawer/test/Drawer.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { addIcons } from '../../../config/fontawesome';
 import Drawer from '..';
+
+beforeAll(() => {
+    addIcons();
+});
 
 describe('Drawer', () => {
     it('should render without crashing', () => {

--- a/src/components/Popup/test/Popup.test.js
+++ b/src/components/Popup/test/Popup.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { addIcons } from '../../../config/fontawesome';
 import Popup from '..';
+
+beforeAll(() => {
+    addIcons();
+});
 
 describe('Popup', () => {
     it('should render without crashing', () => {

--- a/src/components/subcomponents/Icon/index.js
+++ b/src/components/subcomponents/Icon/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { string, func } from 'prop-types';
+import { array, func, oneOfType, string } from 'prop-types';
 import styled from 'styled-components';
 
 const StyledIcon = styled(FontAwesomeIcon)`
@@ -34,7 +34,7 @@ Icon.defaultProps = {
 };
 
 Icon.propTypes = {
-    icon: string,
+    icon: oneOfType([string, array]),
     onClick: func
 };
 

--- a/src/components/subcomponents/Icon/test/Icon.test.js
+++ b/src/components/subcomponents/Icon/test/Icon.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { addIcons } from '../../../../config/fontawesome';
 import Icon from '..';
+
+beforeAll(() => {
+    addIcons();
+});
 
 describe('Icon', () => {
     it('should render without crashing', () => {


### PR DESCRIPTION
Problem:
Tests had warnings relating to icons and proptypes

Solution:
* Import fontawesome icons in tests that have icons in component
* Fix proptypes for Icon component

Note:
N/A